### PR TITLE
feat: linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,4 @@ expires you will have to reauthenticate. Note that your password or 2FA secrets 
 
 ## Platform Compatibility
 
-Currently this only works on Windows as it uses the registry to find the installation path of the game (and
-thus the local manifest file). Linux support is planned.
+Currently this works on both Windows and Linux(tested on Arch).

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ import time
 from typing import Dict, List
 import json
 import psutil
-if sys.platform.startswith("win32"):
+if sys.platform == "win32":
     import winreg
 
 from steam.client import SteamClient
@@ -17,7 +17,7 @@ from steam.client.cdn import CDNClient, CDNDepotManifest
 import steamfiles.acf
 
 def get_game_location(appid: int) -> Path:
-    if sys.platform.startswith("win32"):
+    if sys.platform == "win32":
         #Thank you kinsi55 for this trick
         #https://github.com/kinsi55/BeatSaber_UpdateSkipper/blob/master/Form1.cs
         key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Steam App %i" % appid)
@@ -28,7 +28,7 @@ def get_game_location(appid: int) -> Path:
         return Path(f"{os.getenv('HOME')}/.local/share/Steam/steamapps/some/folder")
 
 def get_steam_location():
-    if sys.platform.startswith("win32"):
+    if sys.platform == "win32":
         try:
             key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Valve\\Steam")
         except OSError as e:
@@ -174,7 +174,7 @@ def disable_updates(appid: int, launch_game=False, disable_auto_update=False, pe
     if steam_need_restart:
         p = get_steam_location()
         try:
-            if sys.platform.startswith('win32'):
+            if sys.platform == 'win32':
                 os.spawnl(os.P_NOWAIT, p, p)
             elif sys.platform == 'linux':
                 subprocess.Popen([p])

--- a/main.py
+++ b/main.py
@@ -17,13 +17,15 @@ from steam.client.cdn import CDNClient, CDNDepotManifest
 import steamfiles.acf
 
 def get_game_location(appid: int) -> Path:
-
-    #Thank you kinsi55 for this trick
-    #https://github.com/kinsi55/BeatSaber_UpdateSkipper/blob/master/Form1.cs
-    key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Steam App %i" % appid)
-    path = winreg.QueryValueEx(key, "InstallLocation")[0]
-    winreg.CloseKey(key)
-    return Path(path)
+    if sys.platform.startswith("win32"):
+        #Thank you kinsi55 for this trick
+        #https://github.com/kinsi55/BeatSaber_UpdateSkipper/blob/master/Form1.cs
+        key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Steam App %i" % appid)
+        path = winreg.QueryValueEx(key, "InstallLocation")[0]
+        winreg.CloseKey(key)
+        return Path(path)
+    elif sys.platform == 'linux':
+        return Path(f"{os.getenv('HOME')}/.local/share/Steam/steamapps/some/folder")
 
 def get_steam_location():
     if sys.platform.startswith("win32"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 steam[client]
 git+https://github.com/WinterPhoenix/steamfiles@patch-1
+psutil


### PR DESCRIPTION
# Add basic linux support

## Known issues

- Does not currently work for non-default steam library locations
- Does not work on systems without bash installed
- Cannot restart steam if it is not in path
  - This is only an issue if you are using an Appimage variant, which is discouraged, since installing it through pacman will make sure it is in path.
 
## Final notes

Before merging, please make sure it works on windows, I wrote this all in bed and do not have quick access to a windows instance to test it (did test it on arch though).